### PR TITLE
fix: add extra example for timestamp

### DIFF
--- a/src/commands/commands.yaml
+++ b/src/commands/commands.yaml
@@ -63,6 +63,6 @@
           type: 3
           required: true
         - name: timezone
-          description: The timezone (e.g. Europe/Zurich)
+          description: The timezone (e.g. Europe/Zurich or Europe/San_Marino)
           type: 3
           required: true

--- a/test/data/test_req_time.json
+++ b/test/data/test_req_time.json
@@ -24,7 +24,7 @@
           },
           {
             "name": "timezone",
-            "description": "The timezone (e.g. Europe/Zurich)",
+            "description": "The timezone (e.g. Europe/Zurich or Europe/San_Marino)",
             "value": "Australia/Melbourne",
             "type": 3
           }


### PR DESCRIPTION
### **Additions**
- Added extra example `Europe/San_Marino` in timestamp create timezone description for clarity that `Europe/Zurich` is the complete timezone identifier